### PR TITLE
Re-specify toolchain versions and update build workflow

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -37,18 +37,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup GCC
-        uses: egor-tensin/setup-gcc@v1
-        with:
-          version: latest
-          platform: x64
-
-      - name: Setup Clang
-        uses: egor-tensin/setup-clang@v1
-        with:
-          version: latest
-          platform: x64
-
       - name: Set reusable strings
         # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
         id: strings

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -15,9 +15,8 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-22.04, macos-12, windows-2022 ]
         build_type: [ Release ]
-        c_compiler: [ gcc, clang ]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: ["main"]
 
+env:
+  LLVM_VERSION: 15
+  GCC_VERSION: 12
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -15,22 +19,23 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [ubuntu-22.04, macos-12]
+        os: [ubuntu-22.04]
         build_type: [Release]
         c_compiler: [clang, gcc]
         include:
           - os: ubuntu-22.04
-            c_compiler: clang
-            cpp_compiler: clang++
+            c_compiler: clang-${{ env.LLVM_VERSION }}
+            cpp_compiler: clang++-${{ env.LLVM_VERSION }}
           - os: ubuntu-22.04
-            c_compiler: gcc
-            cpp_compiler: g++
-          - os: macos-12
-            c_compiler: clang
-            cpp_compiler: clang++
+            c_compiler: gcc-${{ env.GCC_VERSION }}
+            cpp_compiler: g++-${{ env.GCC_VERSION }}
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Setup dependencies
+        run: |
+          sudo apt-get install -y gcc-${{ env.GCC_VERSION }} llvm-${{ env.LLVM_VERSION }} clang-${{ env.LLVM_VERSION }}
 
       - name: Set reusable strings
         # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -17,11 +17,10 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         build_type: [Release]
-        c_compiler: [clang-15, gcc-12]
         include:
           - os: ubuntu-22.04
-            c_compiler: clang-15
-            cpp_compiler: clang++-15
+            c_compiler: clang-16
+            cpp_compiler: clang++-16
           - os: ubuntu-22.04
             c_compiler: gcc-12
             cpp_compiler: g++-12
@@ -31,7 +30,7 @@ jobs:
 
       - name: Setup dependencies
         run: |
-          sudo apt-get install -y gcc-12 llvm-15 clang-15
+          sudo apt-get install -y gcc-12 llvm-16 clang-16
 
       - name: Set reusable strings
         # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -34,6 +34,7 @@ jobs:
           wget --no-check-certificate -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && \
           sudo add-apt-repository 'deb ${{ env.LLVM_REPO }} ${{ env.LLVM_REPO_TOOLCHAIN }} main' &&
           sudo add-apt-repository 'deb-src ${{ env.LLVM_REPO }} ${{ env.LLVM_REPO_TOOLCHAIN }} main' && \
+          sudo apt-get update && \
           sudo apt-get install -y gcc-${{ env.GCC_VERSION }} llvm-${LLVM_VERSION} clang-${LLVM_VERSION}
         env:
           GCC_VERSION: 12

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, macos-latest ]
         build_type: [ Release ]
         c_compiler: [ gcc, clang ]
         include:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -32,12 +32,14 @@ jobs:
       - name: Setup dependencies
         run: |
           wget --no-check-certificate -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && \
-          sudo add-apt-repository 'deb http://apt.llvm.org/${RELEASE_NAME}/ llvm-toolchain-${RELEASE_NAME}-${LLVM_VERSION} main' &&
-          sudo add-apt-repository 'deb-src http://apt.llvm.org/${RELEASE_NAME}/ llvm-toolchain-${RELEASE_NAME}-${LLVM_VERSION} main' && \
-          sudo apt-get install -y gcc-12 llvm-${LLVM_VERSION} clang-${LLVM_VERSION}
+          sudo add-apt-repository 'deb ${{ env.LLVM_REPO }} ${{ env.LLVM_REPO_TOOLCHAIN }} main' &&
+          sudo add-apt-repository 'deb-src ${{ env.LLVM_REPO }} ${{ env.LLVM_REPO_TOOLCHAIN }} main' && \
+          sudo apt-get install -y gcc-${{ env.GCC_VERSION }} llvm-${LLVM_VERSION} clang-${LLVM_VERSION}
         env:
-          RELEASE_NAME: jammy
+          GCC_VERSION: 12
           LLVM_VERSION: 16
+          LLVM_REPO: http://apt.llvm.org/jammy/
+          LLVM_REPO_TOOLCHAIN: llvm-toolchain-jammy-16
 
       - name: Set reusable strings
         # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -18,13 +18,6 @@ jobs:
         os: [ ubuntu-latest, macos-latest ]
         build_type: [ Release ]
         c_compiler: [ gcc, clang ]
-        include:
-          - os: ubuntu-latest
-            c_compiler: gcc
-            cpp_compiler: g++
-          - os: macos-latest
-            c_compiler: clang
-            cpp_compiler: clang++
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,9 +2,9 @@ name: CMake
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   build:
@@ -15,8 +15,19 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [ ubuntu-22.04, macos-12, windows-2022 ]
-        build_type: [ Release ]
+        os: [ubuntu-22.04, macos-12]
+        build_type: [Release]
+        c_compiler: [clang, gcc]
+        include:
+          - os: ubuntu-22.04
+            c_compiler: clang
+            cpp_compiler: clang++
+          - os: ubuntu-22.04
+            c_compiler: gcc
+            cpp_compiler: g++
+          - os: macos-12
+            c_compiler: clang
+            cpp_compiler: clang++
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,25 +14,17 @@ jobs:
       # Set to true when stable.
       fail-fast: false
 
-      # Set up a matrix to run the following configurations:
-      # - <Linux, Release, latest GCC compiler toolchain on the default runner image, default generator>
-      # - <Linux, Release, latest Clang compiler toolchain on the default runner image, default generator>
-      #
-      # More build types (Release, Debug, RelWithDebInfo, etc.) can be added by customizing the build_type list.
       matrix:
         os: [ ubuntu-latest ]
         build_type: [ Release ]
-        c_compiler: [ gcc, clang, cl ]
+        c_compiler: [ gcc, clang ]
         include:
           - os: ubuntu-latest
             c_compiler: gcc
             cpp_compiler: g++
-          - os: ubuntu-latest
+          - os: macos-latest
             c_compiler: clang
             cpp_compiler: clang++
-        exclude:
-          - os: ubuntu-latest
-            c_compiler: cl
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -31,7 +31,13 @@ jobs:
 
       - name: Setup dependencies
         run: |
-          sudo apt-get install -y gcc-12 llvm-16 clang-16
+          wget --no-check-certificate -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add - && \
+          sudo add-apt-repository 'deb http://apt.llvm.org/${RELEASE_NAME}/ llvm-toolchain-${RELEASE_NAME}-${LLVM_VERSION} main' &&
+          sudo add-apt-repository 'deb-src http://apt.llvm.org/${RELEASE_NAME}/ llvm-toolchain-${RELEASE_NAME}-${LLVM_VERSION} main' && \
+          sudo apt-get install -y gcc-12 llvm-${LLVM_VERSION} clang-${LLVM_VERSION}
+        env:
+          RELEASE_NAME: jammy
+          LLVM_VERSION: 16
 
       - name: Set reusable strings
         # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -37,6 +37,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Setup Clang
+        uses: egor-tensin/setup-clang@v1
+        with:
+          version: 15.0.0
+          platform: x64
+
       - name: Set reusable strings
         # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
         id: strings

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         build_type: [Release]
+        c_compiler: [clang-16, gcc-12]
         include:
           - os: ubuntu-22.04
             c_compiler: clang-16

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Setup Clang
         uses: egor-tensin/setup-clang@v1
         with:
-          version: 15.0.0
+          version: latest
           platform: x64
 
       - name: Set reusable strings

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,10 +6,6 @@ on:
   pull_request:
     branches: ["main"]
 
-env:
-  LLVM_VERSION: 15
-  GCC_VERSION: 12
-
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -24,18 +20,18 @@ jobs:
         c_compiler: [clang, gcc]
         include:
           - os: ubuntu-22.04
-            c_compiler: clang-${{ env.LLVM_VERSION }}
-            cpp_compiler: clang++-${{ env.LLVM_VERSION }}
+            c_compiler: clang-15
+            cpp_compiler: clang++-15
           - os: ubuntu-22.04
-            c_compiler: gcc-${{ env.GCC_VERSION }}
-            cpp_compiler: g++-${{ env.GCC_VERSION }}
+            c_compiler: gcc-12
+            cpp_compiler: g++-12
 
     steps:
       - uses: actions/checkout@v3
 
       - name: Setup dependencies
         run: |
-          sudo apt-get install -y gcc-${{ env.GCC_VERSION }} llvm-${{ env.LLVM_VERSION }} clang-${{ env.LLVM_VERSION }}
+          sudo apt-get install -y gcc-12 llvm-15 clang-15
 
       - name: Set reusable strings
         # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -37,6 +37,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Setup GCC
+        uses: egor-tensin/setup-gcc@v1
+        with:
+          version: latest
+          platform: x64
+
       - name: Setup Clang
         uses: egor-tensin/setup-clang@v1
         with:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04]
         build_type: [Release]
-        c_compiler: [clang, gcc]
+        c_compiler: [clang-15, gcc-12]
         include:
           - os: ubuntu-22.04
             c_compiler: clang-15

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.27)
 project(nSnake)
 
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(Curses REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.27)
 project(nSnake)
 
-set(CMAKE_CXX_STANDARD 23)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(Curses REQUIRED)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # nSnake
 
-Text-based console Snake clone for *nix systems, using a modern C++20 project stack.
+Text-based console Snake clone for *nix systems, using a modern C++ project design.
 
 ## Requirements
 
@@ -11,4 +11,7 @@ Text-based console Snake clone for *nix systems, using a modern C++20 project st
 ## Build requirements
 
 - CMake >= 3.27
-- C++20 toolchain
+- C++23 toolchain
+    - Clang >= 16
+    - GCC >= 12
+    - AppleClang >= 15

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # nSnake
 
-Text-based console Snake clone for *nix systems, using a modern C++23 project stack.
+Text-based console Snake clone for *nix systems, using a modern C++20 project stack.
 
 ## Requirements
 
@@ -11,4 +11,4 @@ Text-based console Snake clone for *nix systems, using a modern C++23 project st
 ## Build requirements
 
 - CMake >= 3.27
-- C++17 toolchain (Clang >= 14, GCC >= 11.4.0)
+- C++20 toolchain


### PR DESCRIPTION
Fixes build when libstdc++ non-literals are treated as `constexpr`